### PR TITLE
fix: Add valid links to GitHub and Support buttons in mobile sidebar

### DIFF
--- a/app/Navbar/Navbar.tsx
+++ b/app/Navbar/Navbar.tsx
@@ -207,12 +207,16 @@ const Navbar = () => {
                         <div className=' w-full flex flex-col gap-2 items-center justify-center'>
                             <div className=' w-full flex items-center justify-center gap-2 '>
                                 <Button variant="outline" className=' flex justify-center items-center gap-2 w-full ' >
+                                <Link href="https://github.com/harsh3dev/devmatchups" target="_blank" rel="noopener noreferrer">
                                     <IoLogoGithub />
                                     Github
+                                </Link>
                                 </Button>
                                 <Button variant="outline" className=' flex justify-center items-center gap-2 w-full ' >
+                                    <Link href="mailto:devmatchups@gmail.com">
                                     <MdEmail />
                                     Support
+                                    </Link>
                                 </Button>
                             </div>
 


### PR DESCRIPTION
- Updated the GitHub button in the mobile sidebar to redirect users to the correct repository: https://github.com/harsh3dev/devmatchups.
- Updated the Support button to open the user's default email client with the support email: devmatchups@gmail.com.
- Both buttons are now functional in the mobile sidebar menu.
