### PR TITLE
Add valid links to Github and Support Buttons in Mobile Sidebar menu #15

### DIFF
--- a/app/Navbar/Navbar.tsx
+++ b/app/Navbar/Navbar.tsx
@@ -206,14 +206,19 @@ const Navbar = () => {
                                 <Separator className=' bg-text dark:bg-text mb-6 '  />
                         <div className=' w-full flex flex-col gap-2 items-center justify-center'>
                             <div className=' w-full flex items-center justify-center gap-2 '>
-                                <Button variant="outline" className=' flex justify-center items-center gap-2 w-full ' >
-                                    <IoLogoGithub />
-                                    Github
-                                </Button>
-                                <Button variant="outline" className=' flex justify-center items-center gap-2 w-full ' >
-                                    <MdEmail />
-                                    Support
-                                </Button>
+                                <Link href="https://github.com/harsh3dev/devmatchups">
+                                    <Button variant="outline" className=' flex justify-center items-center gap-2 w-full ' >
+                                        <IoLogoGithub />
+                                        Github
+                                    </Button>
+                                </Link>
+                                
+                                <Link href="mailto:devmatchups@gmail.com">
+                                    <Button variant="outline" className=' flex justify-center items-center gap-2 w-full ' >
+                                        <MdEmail />
+                                        Support
+                                    </Button>
+                                </Link>
                             </div>
 
                             { status==='authenticated' && session && 


### PR DESCRIPTION
Added Link tags to both buttons in Mobile Sidebar menu with links:
GItHub : https://github.com/harsh3dev/devmatchups
Support : devmatchups@gmail.com

![image](https://github.com/user-attachments/assets/3e82d288-69a4-4315-a450-c5a66449ccb5)
