### PR TITLE
Girirajshankar27 patch 1

### DIFF
--- a/app/(dashboard)/(routes)/hackathons/page.tsx
+++ b/app/(dashboard)/(routes)/hackathons/page.tsx
@@ -70,7 +70,7 @@ const Page = () => {
     <div className='min-h-screen w-full text-black dark:bg-background bg-background dark:text-white mb-20 '>
       <div className='w-full mt-16 flex flex-col justify-start items-start gap-5'>
 
-        <div className=" md:ml-10 w-full flex justify-center items-center md:justify-start ">
+        <div className=" w-full flex justify-center items-center md:justify-start ">
           <div className="flex justify-center items-center md:items-start space-x-4 mx-auto w-full ">
             {platforms.map((platform) => (
               <motion.button

--- a/app/Navbar/Navbar.tsx
+++ b/app/Navbar/Navbar.tsx
@@ -207,12 +207,16 @@ const Navbar = () => {
                         <div className=' w-full flex flex-col gap-2 items-center justify-center'>
                             <div className=' w-full flex items-center justify-center gap-2 '>
                                 <Button variant="outline" className=' flex justify-center items-center gap-2 w-full ' >
+                                <Link href="https://github.com/harsh3dev/devmatchups" target="_blank" rel="noopener noreferrer">
                                     <IoLogoGithub />
                                     Github
+                                </Link>
                                 </Button>
                                 <Button variant="outline" className=' flex justify-center items-center gap-2 w-full ' >
+                                    <Link href="mailto:devmatchups@gmail.com">
                                     <MdEmail />
                                     Support
+                                    </Link>
                                 </Button>
                             </div>
 


### PR DESCRIPTION
Fix: Remove extra left margin on "Explore Hackathons" page to eliminate horizontal scrolling
This commit addresses an issue on the "Explore Hackathons" page where an excessive left margin on larger screens was causing unnecessary horizontal scrolling. The `md:ml-10` class has been removed from the relevant div to ensure that the layout is properly aligned and adjusts to the screen size without additional margins. This improvement enhances the overall user experience on desktop devices.
