### PR TITLE
fix: Add valid links to GitHub and Support buttons in mobile sidebar

### DIFF
--- a/app/Navbar/Navbar.tsx
+++ b/app/Navbar/Navbar.tsx
@@ -24,6 +24,8 @@ import { MdDashboard, MdEmail } from 'react-icons/md'
 
 import Logo from '@/app/assets/Devmatchups.svg'
 
+const GITHUB_URL = "https://github.com/harsh3dev/devmatchups";
+const SUPPORT_EMAIL = "mailto:devmatchups@gmail.com";
 
 const Navbar = () => {
     const {data : session , status} = useSession();
@@ -206,14 +208,18 @@ const Navbar = () => {
                                 <Separator className=' bg-text dark:bg-text mb-6 '  />
                         <div className=' w-full flex flex-col gap-2 items-center justify-center'>
                             <div className=' w-full flex items-center justify-center gap-2 '>
-                                <Button variant="outline" className=' flex justify-center items-center gap-2 w-full ' >
-                                    <IoLogoGithub />
-                                    Github
-                                </Button>
-                                <Button variant="outline" className=' flex justify-center items-center gap-2 w-full ' >
-                                    <MdEmail />
-                                    Support
-                                </Button>
+                                <Link href={GITHUB_URL}>
+                                    <Button variant="outline" className=' flex justify-center items-center gap-2 w-full ' >
+                                        <IoLogoGithub />
+                                        Github
+                                    </Button>
+                                </Link>
+                                <Link href={SUPPORT_EMAIL}>
+                                    <Button variant="outline" className=' flex justify-center items-center gap-2 w-full ' >
+                                        <MdEmail />
+                                        Support
+                                    </Button>
+                                </Link>
                             </div>
 
                             { status==='authenticated' && session && 


### PR DESCRIPTION
Added valid links to GitHub and Support buttons with static constant variable 

- GitHub : "https://github.com/harsh3dev/devmatchups"
- Support Email : "devmatchups@gmail.com"

![image](https://github.com/user-attachments/assets/be6b48ff-5b03-44c8-9868-5695af660431)
![image](https://github.com/user-attachments/assets/d19659c6-541e-47f7-9537-8e4f7fe55d2f)
