### PR TITLE
Fix: Update Social Media Links in Footer - Hacktoberfest

### DIFF
--- a/app/Footer/Footer.tsx
+++ b/app/Footer/Footer.tsx
@@ -89,9 +89,21 @@ export default function Footer() {
                     </Link>
                 </h1>
                 <span className=" flex justify-center items-center gap-5   text-xl group ">
-                    <Link target="_blank" href="/" className=" opacity-60 hover:opacity-100 " ><FaProductHunt /></Link>
-                    <Link target="_blank" href="/" className=" opacity-60 hover:opacity-100 " ><FaXTwitter /></Link>
-                    <Link target="_blank" href="/" className=" opacity-60 hover:opacity-100 " ><FaGithub /></Link>
+                    <Link href="https://www.producthunt.com/posts/devmatchups" passHref legacyBehavior>
+                        <a target="_blank" className="opacity-60 hover:opacity-100">
+                            <FaProductHunt />
+                        </a>
+                    </Link>
+                    <Link href="https://twitter.com/devmatchups" passHref legacyBehavior>
+                        <a target="_blank" className="opacity-60 hover:opacity-100">
+                            <FaXTwitter />
+                        </a>
+                    </Link>
+                    <Link href="https://github.com/harsh3dev/devmatchups" passHref legacyBehavior>
+                        <a target="_blank" className="opacity-60 hover:opacity-100">
+                            <FaGithub />
+                        </a>
+                    </Link>
                 </span>
             </div>
         </footer>


### PR DESCRIPTION
### Pull Request: Update Social Media Links in Footer

**Description:**
This PR addresses [Issue #23](https://github.com/harsh3dev/DevMatchups/issues/23), where the social media icons in the footer were pointing to null links. The links have now been updated to the correct URLs, and all links will open in a new tab as expected.


**Changes:**
- Updated the GitHub link to: `https://github.com/harsh3dev/devmatchups`
- Updated the Twitter link to: `https://twitter.com/devmatchups`
- Updated the ProductHunt link to: `https://www.producthunt.com/posts/devmatchups`
- Ensured that all links open in a new tab by adding `target="_blank"` using Next.js `<Link>` component and `<a>` tags.

**Expected Behavior:**
- Each social media icon (GitHub, Twitter, ProductHunt) in the footer now redirects to the correct social media page.
- The links will open in a new tab as intended.

**Steps to Test:**
1. Navigate to the footer section of any page.
2. Click on each social media icon.
3. Verify that each link redirects to the correct page and opens in a new tab.


