### PR TITLE
Fixes issue #72 (Text wrapping in footer)

### DIFF
--- a/app/Footer/Footer.tsx
+++ b/app/Footer/Footer.tsx
@@ -23,11 +23,11 @@ export default function Footer() {
                         </div>
                         <span className=" text-xl lg:text-3xl font-bold">Dev Matchups</span>
                     </Link>
-                    <p className="  text-wrap text-base font-medium py-2 ">Team up for success in every hackathon <br/> Build your dream hackathon team with DevMatchups!</p>
+                    <p className="  text-wrap text-base font-medium py-2 ">Team up for success in every hackathon <br /> Build your dream hackathon team with DevMatchups!</p>
                 </div>
                 <div className="flex sm:flex-wrap lg:flex-nowrap w-full md:w-fit md:px-5 sm:p-0 sm:justify-around lg:justify-between gap-5 sm:gap-20  lg:h-full " >
 
-                <div className=" flex flex-col justify-start items-start lg:h-full gap-4 flex-nowrap text-nowrap  ">
+                    <div className=" flex flex-col justify-start items-start lg:h-full gap-4 flex-nowrap text-nowrap  ">
                         <h3 className=" text-base md:text-lg font-semibold ml-1 ">Supported by</h3>
                         <div className="flex gap-4">
                             <Image src={SwocLogo} alt="SWOC Logo" width={60} height={60} />
@@ -40,15 +40,22 @@ export default function Footer() {
                         <h3 className=" text-base md:text-lg font-semibold ml-1 ">Contribute</h3>
                         <ul className=" flex flex-col lg:justify-between items-start gap-2 text-gray-200 text-xs md:text-base ">
                             <li>
-                                <Link target="_blank" className="flex justify-center items-center gap-2 text-text rounded-md p-1 group " href="https://github.com/harsh3dev/DevMatchups" >
-                                    {/* <FaGithub className=" w-5 h-5 " /> */}
+                                <Link
+                                    target="_blank"
+                                    className="flex flex-nowrap justify-center items-center gap-2 text-text rounded-md p-1 group whitespace-nowrap"
+                                    href="https://github.com/harsh3dev/DevMatchups"
+                                >
                                     Star on GitHub
-                                    <MdArrowOutward className="opacity-0 group-hover:opacity-100 transition-opacity duration-75 ease-linear " />
+                                    <MdArrowOutward className="opacity-0 group-hover:opacity-100 transition-opacity duration-75 ease-linear" />
                                 </Link>
                             </li>
+
                             <li>
-                                <Link target="_blank" className="flex justify-center items-center gap-2 rounded-md p-1 group text-pink-700 dark:text-pink-300 " href="https://github.com/sponsors/harsh3dev" >
-                                    {/* <SiGithubsponsors className=" w-5 h-5 " /> */}
+                                <Link
+                                    target="_blank"
+                                    className="flex flex-nowrap justify-center items-center gap-2 text-text rounded-md p-1 group whitespace-nowrap"
+                                    href="https://github.com/sponsors/harsh3dev" 
+                                >
                                     Sponsor on GitHub
                                     <MdArrowOutward className="opacity-0 group-hover:opacity-100 transition-opacity duration-75 ease-linear " />
                                 </Link>


### PR DESCRIPTION
### *What kind of change does this PR introduce?*  
Frontend (Style "text wrapping issues in the footer ")

---

### *Issue Number:*  
Fixes issue #72

---

### *Did you add tests for your changes?*  
Not required.

---

### *Snapshots/Videos:*  
![Screenshot from 2025-01-04 12-53-24](https://github.com/user-attachments/assets/586c4f13-309d-4a7c-9cd3-952cf16080c1)

---

### Code Base Changes:

**1. Text Wrapping Fix:** 

- Added the `whitespace-nowrap` class to the "Star on GitHub" and "Sponsor on GitHub" links in the footer to prevent the text from wrapping to a new line. This ensures that both links remain on a single line, even on smaller screens.

**2. Flex Layout Update:**

- Applied the `flex-nowrap` class to the parent `flex` containers of the "Star on GitHub" and "Sponsor on GitHub" links. This prevents the child elements from wrapping, keeping the layout intact.

**3. Footer Content Alignment:**
   
- Adjusted the layout of the footer by utilizing Tailwind's flex utility classes (`justify-center`, `items-center`, `gap-2`, etc.) to ensure proper positioning and spacing of elements.

---

### *Summary*  

-Fixed text wrapping issues in the footer by adding text-nowrap and flex-nowrap classes to ensure "Star on GitHub" and "Sponsor on GitHub" links remain on a single line.

- Changes implemented in the following files:  
  - DevMatchups/app/Footer/Footer.jsx

---

### *Does this PR introduce a breaking change?*  
No  

---

### *Other information*  

- CSS (Tailwind): No changes made directly to Tailwind configuration, but utility classes were applied to adjust the layout behavior.


---

### **Have you read the [contributing guide](https://github.com/harsh3dev/DevMatchups/blob/7df07ad9733a1016715811d37ce50b28f5d74dc2/CONTRIBUTING.md)?**  
Yes  