### PR TITLE
Increase the number of latest hackathons in Explore hackathons page

### DIFF
--- a/app/(dashboard)/(routes)/hackathons/Posts.tsx
+++ b/app/(dashboard)/(routes)/hackathons/Posts.tsx
@@ -34,7 +34,12 @@ const Posts:React.FC<PostsProps> = ({title, url, logo, platform}) => {
         transition={{ duration: 0.5, delay: 0.2 }}
       >
         <div className='relative w-10 h-10'>
-          <Image src={Logo} alt={platform} layout='fill' objectFit='contain' className='rounded-full' />
+          <Image src={Logo !== null ? Logo : 
+            platform==='unstop' ? unstop : 
+            platform==='devpost' ? devpost : 
+            platform==='devfolio' ? devfolio : 
+            ''
+          } alt={platform} layout='fill' objectFit='contain' className='rounded-full' />
         </div>
         <h3 className='text-lg font-semibold'>{title}</h3>
       </motion.div>

--- a/app/(dashboard)/(routes)/hackathons/page.tsx
+++ b/app/(dashboard)/(routes)/hackathons/page.tsx
@@ -50,7 +50,7 @@ const Page = () => {
         // console.log("devpost URL", res2.data.hackathon.hackathons[0].thumbnail_url);
         setDevposts(res2?.data?.hackathon?.hackathons);
         // console.log(res1?.data?.hackathon?.data?.data);
-        setUnstopPost(res1?.data?.hackathon?.data?.data);
+        setUnstopPost(res1?.data?.hackathon);
         setDevfolio(res3?.data?.hackathon?.hits.hits);
       } 
       catch (error) {

--- a/app/api/devfolioHackathon/route.ts
+++ b/app/api/devfolioHackathon/route.ts
@@ -5,7 +5,8 @@ export async function GET(req: Request) {
   const devfolioURL = 'https://api.devfolio.co/api/search/hackathons'
   try {
     const response = await axios.post(devfolioURL, {
-        "type": "application_open"
+        "type": "application_open",
+        size: 20,
     });
 
     if (!response.data) {

--- a/app/api/devpostHackathon/route.ts
+++ b/app/api/devpostHackathon/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import axios from 'axios';
 
 export async function GET(req: Request) {
-  const devpostURL = 'https://devpost.com/api/hackathons?order_by=recently-added'
+  const devpostURL = 'https://devpost.com/api/hackathons?order_by=recently-added&per_page=20'
   try {
     const response = await axios.get(devpostURL);
 

--- a/app/api/unstopHackathon/route.ts
+++ b/app/api/unstopHackathon/route.ts
@@ -2,16 +2,36 @@ import { NextResponse } from 'next/server';
 import axios from 'axios';
 
 export async function GET(req: Request) {
-  const unstopURL = 'https://unstop.com/api/public/opportunity/search-result?opportunity=hackathons&oppstatus=recent';
+  const unstopURL = 'https://unstop.com/api/public/opportunity/search-result';
+
+  const params = {
+    opportunity: 'hackathons',
+    oppstatus: 'recent',
+  }
 
   try {
-    const response = await axios.get(unstopURL);
+    const responses = await Promise.all([
+      axios.get(unstopURL, { 
+        params:{
+          ...params,
+          page : 1
+        }
+      }),
+      axios.get(unstopURL,{
+        params:{
+          ...params,
+          page : 2
+        }
+      }),
+    ])
 
-    if (!response.data) {
+    const hackathons = responses.flatMap(response => response.data.data.data || []);
+
+    if (!hackathons.length) {
       return NextResponse.json({ error: 'Hackathon not found' }, { status: 404 });
     }
 
-    return NextResponse.json({ hackathon: response.data }, { status: 200 });
+    return NextResponse.json({ hackathon: hackathons }, { status: 200 });
   } catch (error: any) {
     console.error(error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });


### PR DESCRIPTION
Fix issue : #137 

This pull request includes several changes to improve the handling of hackathon data across different platforms. The most important changes include updating the image source logic, modifying the API response handling, and increasing the number of hackathons fetched from APIs.

### Image Source Logic Update:
* [`app/(dashboard)/(routes)/hackathons/Posts.tsx`](diffhunk://#diff-5889fbad03fed34973daeddf4bdeaaf1bbdcf57afd721c627459149ddbcbef22L37-R42): Updated the image source logic to handle cases where `Logo` is `null` and to provide default images based on the `platform` value.

### API Response Handling:
* [`app/(dashboard)/(routes)/hackathons/page.tsx`](diffhunk://#diff-66308d9a0c4b9c131f97375bf9fe3f40cce485c2f78ea858d325cd54ea2698dcL53-R53): Modified the `setUnstopPost` function to directly set the `hackathon` data instead of accessing nested data.

### Increased Hackathon Fetch Limit:
* [`app/api/devfolioHackathon/route.ts`](diffhunk://#diff-def8e718f07de5975382c42bc2b4f08ef070f5bff8da284f1cac48b8b628df8fL8-R9): Added a `size` parameter to the request payload to fetch more hackathons from the Devfolio API.
* [`app/api/devpostHackathon/route.ts`](diffhunk://#diff-653a18808ccf2e1dd4b991fc074cd655586647f0955401d3c9117ed274578bdaL5-R5): Updated the Devpost API URL to include the `per_page` parameter to fetch more hackathons per page.
* [`app/api/unstopHackathon/route.ts`](diffhunk://#diff-b9b2fc6640587f2922766a3ca169f6f4290b4ef18ead6dee3ccdb1695e0ee3ceL5-R34): Modified the Unstop API request to fetch hackathons from multiple pages and combine the results.

### Video

https://github.com/user-attachments/assets/cf8d1fda-ec31-4ff3-983a-9aee2bdb0696

