### PR TITLE
Autofill linkedin and github url from profile

### DIFF
--- a/app/(dashboard)/(routes)/teams/[id]/page.tsx
+++ b/app/(dashboard)/(routes)/teams/[id]/page.tsx
@@ -64,15 +64,14 @@ export default function Page({ params }: { params: { id: string } }) {
                 const userData = response.data.user;
                 setUserData(userData);
                 console.log("User data:", response.data);
-
+                setLinkedinUrl(userData?.linkedinUrl as string);
+                setGithubUrl(userData?.githubUrl as string);
+                setResumeUrl(userData?.resumeUrl as string);
             } catch (error) {
                 console.error("Error fetching user data:", error);
             }
         };
         fetchUserData();
-        setLinkedinUrl(userData?.linkedinUrl as string);
-        setGithubUrl(userData?.githubUrl as string);
-        setResumeUrl(userData?.resumeUrl as string);
     }, [session]);
     useEffect(()=>{
         if(isApplied)


### PR DESCRIPTION
Fix issue : #135 

This pull request includes a small change to the `app/(dashboard)/(routes)/teams/[id]/page.tsx` file. The change ensures that LinkedIn, GitHub, and resume URLs are set only after successfully fetching user data.

* `app/(dashboard)/(routes)/teams/[id]/page.tsx`: Moved the setting of `linkedinUrl`, `githubUrl`, and `resumeUrl` inside the `fetchUserData` function to ensure they are set only after user data is successfully fetched. 