### PR TITLE
Close popup modal after save button action

### DIFF
--- a/app/dashboard/profile/EditProfile.tsx
+++ b/app/dashboard/profile/EditProfile.tsx
@@ -11,6 +11,7 @@ import {
     DialogTrigger,
     } from "@/components/ui/dialog"
 import EditProfileForm from './EditProfileForm'
+import useToggleForm from '@/hooks/useToggleForm'
 
 
 interface PropInterface{
@@ -18,15 +19,16 @@ interface PropInterface{
 }
 
 const EditProfile:React.FC<PropInterface> = ({className}) => {
+    const { isOpen,setIsOpen } = useToggleForm();
     return (
-        <Dialog>
-            <DialogTrigger asChild>
+        <Dialog open={isOpen}>
+            <DialogTrigger asChild onClick={()=>setIsOpen(true)}>
                 <div className={`w-fit px-4 py-2 cursor-pointer font-semibold rounded-lg bg-gray-900 dark:bg-gray-100 text-white dark:text-black flex justify-center items-center gap-2 text-xs sm:text-lg  ${className} `}>
                     <MdModeEdit />
                     <span>Edit Profile</span>
                 </div>
             </DialogTrigger>
-            <DialogContent className="sm:max-w-[50vw] max-h-[90vh] ">
+            <DialogContent className="sm:max-w-[50vw] max-h-[90vh]" onClick={() => setIsOpen(false)}>
                 <DialogHeader>
                     <DialogTitle>Edit profile</DialogTitle>
                     <DialogDescription>

--- a/app/dashboard/profile/EditProfile.tsx
+++ b/app/dashboard/profile/EditProfile.tsx
@@ -21,21 +21,21 @@ interface PropInterface{
 const EditProfile:React.FC<PropInterface> = ({className}) => {
     const { isOpen,setIsOpen } = useToggleForm();
     return (
-        <Dialog open={isOpen}>
-            <DialogTrigger asChild onClick={()=>setIsOpen(true)}>
+        <Dialog open={isOpen} onOpenChange={setIsOpen}>
+            <DialogTrigger asChild>
                 <div className={`w-fit px-4 py-2 cursor-pointer font-semibold rounded-lg bg-gray-900 dark:bg-gray-100 text-white dark:text-black flex justify-center items-center gap-2 text-xs sm:text-lg  ${className} `}>
                     <MdModeEdit />
                     <span>Edit Profile</span>
                 </div>
             </DialogTrigger>
-            <DialogContent className="sm:max-w-[50vw] max-h-[90vh]" onClick={() => setIsOpen(false)}>
+            <DialogContent className="sm:max-w-[50vw] max-h-[90vh]">
                 <DialogHeader>
                     <DialogTitle>Edit profile</DialogTitle>
                     <DialogDescription>
                         Make necessary changes to your profile
                     </DialogDescription>
                 </DialogHeader>
-                    <EditProfileForm/>
+                    <EditProfileForm setIsOpen={setIsOpen}/>
                 <DialogFooter>
                     
                 </DialogFooter>

--- a/app/dashboard/profile/EditProfileForm.tsx
+++ b/app/dashboard/profile/EditProfileForm.tsx
@@ -19,6 +19,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import axios from "axios";
 import { toast } from "react-toastify";
+import useToggleForm from "@/hooks/useToggleForm";
 
 const formatSkillsData = (skills: string | string[]) => {
   if (typeof skills === "string") {
@@ -33,6 +34,7 @@ const formatSkillsData = (skills: string | string[]) => {
 const EditProfileForm = () => {
   const dispatch = useAppDispatch();
   const user = useAppSelector(selectUser);
+  const { isOpen,setIsOpen } = useToggleForm();
 
   const {
     register,
@@ -57,6 +59,8 @@ const EditProfileForm = () => {
       const response = await axios.post("/api/user", data);
       if (response.status === 200) {
         toast.success("Profile Updated Succesfully successfully!");
+        setIsOpen(false);
+        console.log(isOpen);
       }
     } catch (error) {
       console.log(error);

--- a/app/dashboard/profile/EditProfileForm.tsx
+++ b/app/dashboard/profile/EditProfileForm.tsx
@@ -19,7 +19,6 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import axios from "axios";
 import { toast } from "react-toastify";
-import useToggleForm from "@/hooks/useToggleForm";
 
 const formatSkillsData = (skills: string | string[]) => {
   if (typeof skills === "string") {
@@ -31,10 +30,9 @@ const formatSkillsData = (skills: string | string[]) => {
   return skills;
 };
 
-const EditProfileForm = () => {
+const EditProfileForm = ({ setIsOpen } : { setIsOpen:React.Dispatch<React.SetStateAction<boolean>>}) => {
   const dispatch = useAppDispatch();
   const user = useAppSelector(selectUser);
-  const { isOpen,setIsOpen } = useToggleForm();
 
   const {
     register,
@@ -60,7 +58,6 @@ const EditProfileForm = () => {
       if (response.status === 200) {
         toast.success("Profile Updated Succesfully successfully!");
         setIsOpen(false);
-        console.log(isOpen);
       }
     } catch (error) {
       console.log(error);

--- a/hooks/useToggleForm.ts
+++ b/hooks/useToggleForm.ts
@@ -1,0 +1,13 @@
+"use client";
+import React, { useState } from 'react';
+
+const useToggleForm = () => {
+    const [isOpen,setIsOpen] = useState(false);
+
+    return {
+        isOpen,
+        setIsOpen
+    }
+}
+
+export default useToggleForm;

--- a/lib/store/features/userSlice/userSlice.ts
+++ b/lib/store/features/userSlice/userSlice.ts
@@ -14,7 +14,7 @@ export interface UserState {
   applications: any[];
   hackathons: any[];
   accounts: any[];
-  skills: string[];
+  skills: string[] | string;
   resumeUrl: string | null;
   linkedinUrl: string | null;
   githubUrl: string | null;


### PR DESCRIPTION
FIx issue: #132 
This pull request introduces a new custom hook to manage the state of the form's visibility and integrates it into the `EditProfile` and `EditProfileForm` components. The changes aim to improve the user experience by providing better control over the form's open and close states.

Key changes include:

### Integration of `useToggleForm` hook:

* [`app/dashboard/profile/EditProfile.tsx`](diffhunk://#diff-941746b90d24e1517a6b988b5cacf8c990d59726699f1e9ccf9521671955aca9R14-R31): Imported `useToggleForm` and used it to manage the dialog's open state.
* [`app/dashboard/profile/EditProfileForm.tsx`](diffhunk://#diff-db24ea84c30c9ecdafa96fa98d14e6725d815d911e836a23ce382af1de2c2e59R22): Imported `useToggleForm` and used it to close the form upon successful profile update.

### New custom hook:

* [`hooks/useToggleForm.ts`](diffhunk://#diff-bfe6d4d71cb15c06db2088dd6892ad3d96d20acfdf489f22e465c0ffe5f196eaR1-R13): Created a new custom hook `useToggleForm` to manage the open state of the form using `useState`.