### PR TITLE
added favorites functionality for hackathons

### DIFF
--- a/app/(dashboard)/(routes)/favorites/components/favorites-list.tsx
+++ b/app/(dashboard)/(routes)/favorites/components/favorites-list.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import axios from "axios";
+import PostCard from "../../teams/components/PostCard";
+import { HackathonEntry } from "@/app/(dashboard)/(routes)/findmember/Form/types";
+import { useFavorites } from "@/app/hooks/use-favorites";
+
+export const FavoritesList = () => {
+  const [favorites, setFavorites] = useState<HackathonEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { loadExternalFavorites } = useFavorites();
+
+  useEffect(() => {
+    const fetchFavorites = async () => {
+      try {
+        const response = await axios.get("/api/favorites");
+        setFavorites(response.data.map((fav: any) => fav.hackathon));
+        loadExternalFavorites(); // Update the global favorites state
+      } catch (error) {
+        console.error("Failed to fetch favorites", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchFavorites();
+  }, [loadExternalFavorites]);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (favorites.length === 0) {
+    return (
+      <div className="text-center mt-10">
+        <p className="text-muted-foreground">No favorite hackathons yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {favorites.map((hackathon) => (
+        <PostCard key={hackathon.id} entry={hackathon} />
+      ))}
+    </div>
+  );
+};

--- a/app/(dashboard)/(routes)/favorites/components/favorites-list.tsx
+++ b/app/(dashboard)/(routes)/favorites/components/favorites-list.tsx
@@ -9,18 +9,9 @@ export const FavoritesList = () => {
   const { favoriteIds, loadExternalFavorites } = useFavorites();
 
   useEffect(() => {
-    const initializeFavorites = async () => {
-      try {
-        await loadExternalFavorites();
-      } catch (error) {
-        console.error("Failed to fetch favorites", error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    initializeFavorites();
-  }, [loadExternalFavorites]);
+    // Don't load favorites here as they are loaded centrally in the main hackathons page
+    setLoading(false);
+  }, []);
 
   if (loading) {
     return <div>Loading...</div>;

--- a/app/(dashboard)/(routes)/favorites/components/favorites-list.tsx
+++ b/app/(dashboard)/(routes)/favorites/components/favorites-list.tsx
@@ -1,22 +1,17 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import axios from "axios";
 import PostCard from "../../teams/components/PostCard";
-import { HackathonEntry } from "@/app/(dashboard)/(routes)/findmember/Form/types";
 import { useFavorites } from "@/app/hooks/use-favorites";
 
 export const FavoritesList = () => {
-  const [favorites, setFavorites] = useState<HackathonEntry[]>([]);
   const [loading, setLoading] = useState(true);
-  const { loadExternalFavorites } = useFavorites();
+  const { favoriteIds, loadExternalFavorites } = useFavorites();
 
   useEffect(() => {
-    const fetchFavorites = async () => {
+    const initializeFavorites = async () => {
       try {
-        const response = await axios.get("/api/favorites");
-        setFavorites(response.data.map((fav: any) => fav.hackathon));
-        loadExternalFavorites(); // Update the global favorites state
+        await loadExternalFavorites();
       } catch (error) {
         console.error("Failed to fetch favorites", error);
       } finally {
@@ -24,14 +19,14 @@ export const FavoritesList = () => {
       }
     };
 
-    fetchFavorites();
+    initializeFavorites();
   }, [loadExternalFavorites]);
 
   if (loading) {
     return <div>Loading...</div>;
   }
 
-  if (favorites.length === 0) {
+  if (favoriteIds.length === 0) {
     return (
       <div className="text-center mt-10">
         <p className="text-muted-foreground">No favorite hackathons yet.</p>
@@ -40,10 +35,8 @@ export const FavoritesList = () => {
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      {favorites.map((hackathon) => (
-        <PostCard key={hackathon.id} entry={hackathon} />
-      ))}
+    <div className="text-center mt-10">
+      <p className="text-muted-foreground">External favorite hackathons are displayed in the Hackathons page under the "Favorites" tab.</p>
     </div>
   );
 };

--- a/app/(dashboard)/(routes)/favorites/components/favorites-list.tsx
+++ b/app/(dashboard)/(routes)/favorites/components/favorites-list.tsx
@@ -27,7 +27,7 @@ export const FavoritesList = () => {
 
   return (
     <div className="text-center mt-10">
-      <p className="text-muted-foreground">External favorite hackathons are displayed in the Hackathons page under the "Favorites" tab.</p>
+      <p className="text-muted-foreground">External favorite hackathons are displayed in the Hackathons page under the &quot;Favorites&quot; tab.</p>
     </div>
   );
 };

--- a/app/(dashboard)/(routes)/favorites/page.tsx
+++ b/app/(dashboard)/(routes)/favorites/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from "next/navigation";
+import { Heading } from "../../../../components/heading";
+import { FaStar } from "react-icons/fa";
+import { Suspense } from "react";
+import { FavoritesList } from "./components/favorites-list";
+import { auth } from "@/auth";
+
+export default async function FavoritesPage() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  return (
+    <div>
+      <Heading
+        title="Favorite Hackathons"
+        description="View and manage your favorite hackathons"
+        icon={FaStar}
+        iconColor="text-yellow-500"
+        bgColor="bg-yellow-500/10"
+      />
+      <div className="px-4 lg:px-8">
+        <Suspense fallback={<div>Loading...</div>}>
+          <FavoritesList />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/(routes)/hackathons/Posts.tsx
+++ b/app/(dashboard)/(routes)/hackathons/Posts.tsx
@@ -25,13 +25,9 @@ interface PostsProps {
 }
 
 const Posts:React.FC<PostsProps> = ({id, title, url, logo, platform, mode, location, status, onFavoriteChange}) => {
-    const { toggleExternalFavorite, isExternalFavorited, loadExternalFavorites } = useFavorites();
+    const { toggleExternalFavorite, isExternalFavorited } = useFavorites();
     const { data: session, status: sessionStatus } = useSession();
     const router = useRouter();
-
-    useEffect(() => {
-        loadExternalFavorites();
-    }, [loadExternalFavorites]);
 
     const handleFavoriteClick = async (e: React.MouseEvent) => {
         e.preventDefault();

--- a/app/(dashboard)/(routes)/hackathons/Posts.tsx
+++ b/app/(dashboard)/(routes)/hackathons/Posts.tsx
@@ -1,12 +1,19 @@
-import React from 'react'
+'use client';
+
+import React, { useEffect } from 'react'
 import unstop from '@/app/assets/unstop.png'
 import devpost from '@/app/assets/devpost.svg'
 import devfolio from '@/app/assets/Devfolio.svg'
 import { LuExternalLink } from "react-icons/lu";
+import { FaRegStar, FaStar } from "react-icons/fa";
 import Image from 'next/image'
 import { motion } from 'framer-motion';
+import { useFavorites } from '@/app/hooks/use-favorites';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 
 interface PostsProps {
+    id: string,
     title: string,
     url: string,
     logo: string,
@@ -14,38 +21,93 @@ interface PostsProps {
     mode?: string,
     location?: string,
     status?: string,
+    onFavoriteChange?: () => void,
 }
 
-const Posts:React.FC<PostsProps> = ({title, url, logo, platform, mode, location, status}) => {
+const Posts:React.FC<PostsProps> = ({id, title, url, logo, platform, mode, location, status, onFavoriteChange}) => {
+    const { toggleExternalFavorite, isExternalFavorited, loadExternalFavorites } = useFavorites();
+    const { data: session, status: sessionStatus } = useSession();
+    const router = useRouter();
+
+    useEffect(() => {
+        loadExternalFavorites();
+    }, [loadExternalFavorites]);
+
+    const handleFavoriteClick = async (e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        
+        // Check if user is authenticated
+        if (sessionStatus === "loading") return; // Wait for session to load
+        if (!session) {
+            router.push("/login");
+            return;
+        }
+        
+        const hackathon = {
+            id,
+            title,
+            url,
+            logo,
+            platform,
+            mode,
+            location,
+            status,
+        };
+        
+        await toggleExternalFavorite(hackathon);
+        
+        // Call the refresh callback if provided (for favorites page)
+        if (onFavoriteChange) {
+            onFavoriteChange();
+        }
+    };
     const URL = (platform==='unstop' && `https://unstop.com/${url}`) || (platform==='devpost' && `${url}`) || (platform==='devfolio' && `https://${url}`) || '';
     const Logo = (platform==='unstop' || platform==='devpost') ? (logo.startsWith('http') ? logo : 'https:' + logo) : logo;    
 
   return (
-    <motion.a 
-      href={URL} 
-      target='_blank' 
-      className='group min-w-[20vw] min-h-[20vh] px-5 py-4 flex flex-col justify-between items-start flex-wrap rounded-lg border border-gray-500 dark:border-gray-800 dark:backdrop-blur-xl transition-all ease-in-out duration-500 hover:border-accent hover:shadow-xl hover:scale-110 hover:bg-gray-200 dark:hover:bg-gray-700'
+    <motion.div 
+      className='group min-w-[20vw] min-h-[20vh] px-5 py-4 flex flex-col justify-between items-start flex-wrap rounded-lg border border-gray-500 dark:border-gray-800 dark:backdrop-blur-xl transition-all ease-in-out duration-500 hover:border-accent hover:shadow-xl hover:scale-110 hover:bg-gray-200 dark:hover:bg-gray-700 relative'
       whileHover={{ scale: 1.1, boxShadow: "0px 6px 15px rgba(0, 0, 0, 0.3)" }}
       initial={{ opacity: 0, y: 30 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, ease: "easeOut" }}
     >
-      <motion.div 
-        className='flex items-center space-x-3'
+      {/* Star button positioned at top right */}
+      <button
+        onClick={handleFavoriteClick}
+        className={`absolute top-3 right-3 p-1 transition-transform z-10 ${
+          session ? 'hover:scale-110' : 'hover:scale-105 opacity-70'
+        }`}
+        title={!session ? "Login to favorite hackathons" : ""}
+      >
+        {session && isExternalFavorited(id, platform) ? (
+          <FaStar className="w-5 h-5 text-yellow-500" />
+        ) : (
+          <FaRegStar className={`w-5 h-5 ${!session ? 'text-gray-400' : ''}`} />
+        )}
+      </button>
+
+      {/* Main content that links to hackathon */}
+      <motion.a 
+        href={URL} 
+        target='_blank' 
+        className='w-full h-full flex flex-col justify-between'
         initial={{ opacity: 0, x: -20 }}
         animate={{ opacity: 1, x: 0 }}
         transition={{ duration: 0.5, delay: 0.2 }}
       >
-        <div className='relative w-10 h-10'>
-          <Image src={Logo !== null ? Logo : 
-            platform==='unstop' ? unstop : 
-            platform==='devpost' ? devpost : 
-            platform==='devfolio' ? devfolio : 
-            ''
-          } alt={platform} layout='fill' objectFit='contain' className='rounded-full' />
+        <div className='flex items-center space-x-3'>
+          <div className='relative w-10 h-10'>
+            <Image src={Logo !== null ? Logo : 
+              platform==='unstop' ? unstop : 
+              platform==='devpost' ? devpost : 
+              platform==='devfolio' ? devfolio : 
+              ''
+            } alt={platform} layout='fill' objectFit='contain' className='rounded-full' />
+          </div>
+          <h3 className='text-lg font-semibold pr-8'>{title}</h3>
         </div>
-        <h3 className='text-lg font-semibold'>{title}</h3>
-      </motion.div>
       {(mode || location) && (
         <motion.div 
           className='flex flex-wrap gap-2 mt-2 text-sm text-gray-600 dark:text-gray-400'
@@ -77,15 +139,16 @@ const Posts:React.FC<PostsProps> = ({title, url, logo, platform, mode, location,
           )}
         </motion.div>
       )}
-      <motion.div
-        className='opacity-0 group-hover:opacity-100 transition-opacity duration-300'
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.3, delay: 0.4 }}
-      >
-        <LuExternalLink size={20} />
-      </motion.div>
-    </motion.a>
+        <motion.div
+          className='opacity-0 group-hover:opacity-100 transition-opacity duration-300'
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.3, delay: 0.4 }}
+        >
+          <LuExternalLink size={20} />
+        </motion.div>
+      </motion.a>
+    </motion.div>
   )
 }
 

--- a/app/(dashboard)/(routes)/hackathons/page.tsx
+++ b/app/(dashboard)/(routes)/hackathons/page.tsx
@@ -28,19 +28,13 @@ const Page = () => {
   const { data: session, status } = useSession();
   const router = useRouter();
 
-  // Memoize the favorites loading function to prevent unnecessary re-renders
-  const memoizedLoadFavorites = useCallback(() => {
-    if (session?.user?.id) {
-      loadExternalFavorites();
-    }
-  }, [session?.user?.id, loadExternalFavorites]);
-
   const platforms = [
     { name: "Unstop", logo: unstop },
     { name: "Devpost", logo: devpost },
     { name: "Devfolio", logo: devfolioImg },
   ]
 
+  // Separate useEffect for hackathon data fetching (runs only once)
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
@@ -86,8 +80,17 @@ const Page = () => {
     };
 
     fetchData();
-    
-    // Load favorites if user is authenticated
+  }, []); // No dependencies - runs only once on mount
+
+  // Memoize the load favorites function to satisfy linter dependencies
+  const memoizedLoadFavorites = useCallback(() => {
+    if (session?.user?.id) {
+      loadExternalFavorites();
+    }
+  }, [session?.user?.id, loadExternalFavorites]);
+
+  // Separate useEffect for favorites loading (depends only on session)
+  useEffect(() => {
     memoizedLoadFavorites();
   }, [memoizedLoadFavorites]);
 

--- a/app/(dashboard)/(routes)/teams/components/PostCard.tsx
+++ b/app/(dashboard)/(routes)/teams/components/PostCard.tsx
@@ -6,7 +6,10 @@ import { Button } from '@/components/ui/button';
 import { IoLocationSharp } from "react-icons/io5";
 import { MdBugReport } from "react-icons/md";
 import { FaBusinessTime } from "react-icons/fa";
+import { FaRegStar, FaStar } from "react-icons/fa";
 import Link from 'next/link';
+import { useFavorites } from "@/app/hooks/use-favorites";
+import { useEffect } from "react";
 
 import { HackathonEntry } from '@/app/(dashboard)/(routes)/findmember/Form/types';
 
@@ -17,6 +20,27 @@ interface PostCardProps {
 
 
 const PostCard: React.FC<PostCardProps> = ({ entry, className }) => {
+  const { toggleExternalFavorite, isExternalFavorited, loadExternalFavorites } = useFavorites();
+
+  useEffect(() => {
+    loadExternalFavorites();
+  }, [loadExternalFavorites]);
+
+  const handleFavoriteClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const hackathon = {
+      id: entry.id.toString(),
+      title: entry.hackathonName,
+      url: entry.regURL,
+      logo: '',
+      platform: 'local',
+      mode: entry.hackathonMode,
+      location: entry.location,
+      status: '',
+    };
+    toggleExternalFavorite(hackathon);
+  };
+
   function timeDifference(givenTime: string): string {
     const now = new Date();
     const givenDate = new Date(givenTime);
@@ -43,9 +67,21 @@ const PostCard: React.FC<PostCardProps> = ({ entry, className }) => {
     <div className='min-w-[20vw] min-h-[20vh] px-5 py-4 flex flex-col justify-between items-start rounded-lg border border-gray-500 dark:border-gray-800 dark:backdrop-blur-xl transition-all ease-linear hover:border-accent hover:dark:border-accent dark:bg-gray-900/60 hover:dark:bg-blue-900/30 bg-sky-100/70 hover:bg-sky-300/40  '>      
       <div className='w-full flex flex-col justify-between items-start rounded-lg '>
         <div className=' w-full flex justify-between items-center'>
-          <h1 className='font-bold text-2xl ' >
-            {entry.hackathonName}
-          </h1>
+          <div className="flex items-center gap-2">
+            <h1 className='font-bold text-2xl' >
+              {entry.hackathonName}
+            </h1>
+            <button
+              onClick={handleFavoriteClick}
+              className="p-1 hover:scale-110 transition-transform"
+            >
+              {isExternalFavorited(entry.id.toString(), 'local') ? (
+                <FaStar className="w-6 h-6 text-yellow-500" />
+              ) : (
+                <FaRegStar className="w-6 h-6" />
+              )}
+            </button>
+          </div>
           <Capsule item={entry.hackathonMode} key={entry.hackathonMode} className='bg-green-700/80 dark:bg-green-300/50  text-white dark:text-black hover:bg-green-800/80 hover:dark:bg-green-600/80  ' />
         </div>
 

--- a/app/(dashboard)/(routes)/teams/components/PostCard.tsx
+++ b/app/(dashboard)/(routes)/teams/components/PostCard.tsx
@@ -20,11 +20,7 @@ interface PostCardProps {
 
 
 const PostCard: React.FC<PostCardProps> = ({ entry, className }) => {
-  const { toggleExternalFavorite, isExternalFavorited, loadExternalFavorites } = useFavorites();
-
-  useEffect(() => {
-    loadExternalFavorites();
-  }, [loadExternalFavorites]);
+  const { toggleExternalFavorite, isExternalFavorited } = useFavorites();
 
   const handleFavoriteClick = (e: React.MouseEvent) => {
     e.preventDefault();

--- a/app/Navbar/Navbar.tsx
+++ b/app/Navbar/Navbar.tsx
@@ -21,6 +21,7 @@ import { FaCodeBranch } from "react-icons/fa6";
 import { TbUserSearch } from "react-icons/tb";
 import { IoLogoGithub, IoMdLogOut } from 'react-icons/io'
 import { MdDashboard, MdEmail } from 'react-icons/md'
+import { FaStar } from 'react-icons/fa'
 
 import Logo from '@/app/assets/Devmatchups.svg'
 
@@ -42,6 +43,11 @@ const Navbar = () => {
             title: 'Explore Hackathons',
             icon: <GoCodescan className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-primary" />,
             link: '/hackathons'
+        },
+        {
+            title: 'Favorites',
+            icon: <FaStar className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-primary" />,
+            link: '/favorites'
         }
     ] as const;
     const navItems = [

--- a/app/api/external-favorites/route.ts
+++ b/app/api/external-favorites/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(req: Request) {
+  try {
+    const session = await auth();
+    const userId = session?.user?.id;
+    const { 
+      externalId, 
+      title, 
+      url, 
+      logo, 
+      platform, 
+      mode, 
+      location, 
+      status 
+    } = await req.json();
+
+    if (!userId) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    if (!externalId || !platform) {
+      return new NextResponse("Missing required fields", { status: 400 });
+    }
+
+    // Check if already favorited
+    const existingFavorite = await prisma.externalHackathonFavorite.findUnique({
+      where: {
+        userId_externalId_platform: {
+          userId,
+          externalId,
+          platform,
+        },
+      },
+    });
+
+    if (existingFavorite) {
+      // If already favorited, unfavorite it
+      await prisma.externalHackathonFavorite.delete({
+        where: {
+          userId_externalId_platform: {
+            userId,
+            externalId,
+            platform,
+          },
+        },
+      });
+      return NextResponse.json({ favorited: false });
+    }
+
+    // If not favorited, create a new favorite
+    // Only create if we have the required fields for creation
+    if (!title || !url) {
+      return new NextResponse("Missing required fields for creation", { status: 400 });
+    }
+    
+    await prisma.externalHackathonFavorite.create({
+      data: {
+        userId,
+        externalId,
+        title,
+        url,
+        logo,
+        platform,
+        mode,
+        location,
+        status,
+      },
+    });
+
+    return NextResponse.json({ favorited: true });
+  } catch (error) {
+    console.error("[EXTERNAL_FAVORITES_ERROR]", error);
+    return new NextResponse("Internal Error", { status: 500 });
+  }
+}
+
+export async function GET(req: Request) {
+  try {
+    const session = await auth();
+    const userId = session?.user?.id;
+    const { searchParams } = new URL(req.url);
+    const externalId = searchParams.get("externalId");
+    const platform = searchParams.get("platform");
+
+    if (!userId) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    if (externalId && platform) {
+      // Check if specific external hackathon is favorited
+      const favorite = await prisma.externalHackathonFavorite.findUnique({
+        where: {
+          userId_externalId_platform: {
+            userId,
+            externalId,
+            platform,
+          },
+        },
+      });
+      return NextResponse.json({ favorited: !!favorite });
+    }
+
+    // Get all favorited external hackathons
+    const favorites = await prisma.externalHackathonFavorite.findMany({
+      where: {
+        userId,
+      },
+    });
+
+    return NextResponse.json(favorites);
+  } catch (error) {
+    console.error("[EXTERNAL_FAVORITES_GET_ERROR]", error);
+    return new NextResponse("Internal Error", { status: 500 });
+  }
+}

--- a/app/dashboard/MobileNav.tsx
+++ b/app/dashboard/MobileNav.tsx
@@ -19,7 +19,7 @@ import { TbUserSearch } from 'react-icons/tb'
 import { FaCodeBranch } from 'react-icons/fa6'
 import { GoCodescan } from 'react-icons/go'
 import { RiEdit2Fill } from "react-icons/ri";
-import { FaCheckCircle } from "react-icons/fa";
+import { FaCheckCircle, FaStar } from "react-icons/fa";
 import { PiGitPullRequestBold } from "react-icons/pi";
 import { IoLogoGithub, IoMdLogOut } from 'react-icons/io'
 import { MdEmail } from 'react-icons/md'
@@ -44,6 +44,11 @@ const navLinks = [
         title: 'Explore Hackathons',
         icon: <GoCodescan className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-primary" />,
         link: '/hackathons'
+    },
+    {
+        title: 'Favorites',
+        icon: <FaStar className="h-5 w-5 text-muted-foreground transition-colors group-hover:text-primary" />,
+        link: '/favorites'
     }
 ] as const;
 

--- a/app/hooks/use-favorites.ts
+++ b/app/hooks/use-favorites.ts
@@ -11,7 +11,7 @@ import {
   removeExternalFavorite,
   toggleExternalFavorite
 } from "@/lib/store/features/favoritesSlice/favoritesSlice";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 
 interface ExternalHackathon {
   id: string;

--- a/app/hooks/use-favorites.ts
+++ b/app/hooks/use-favorites.ts
@@ -1,0 +1,101 @@
+'use client';
+
+import { create } from "zustand";
+import axios from "axios";
+import { toast } from "react-hot-toast";
+
+interface ExternalHackathon {
+  id: string;
+  title: string;
+  url: string;
+  logo?: string;
+  platform: string;
+  mode?: string;
+  location?: string;
+  status?: string;
+}
+
+interface FavoritesStore {
+  favoriteIds: string[];
+  addExternalFavorite: (hackathon: ExternalHackathon) => Promise<void>;
+  removeExternalFavorite: (externalId: string, platform: string) => Promise<void>;
+  toggleExternalFavorite: (hackathon: ExternalHackathon) => Promise<void>;
+  isExternalFavorited: (externalId: string, platform: string) => boolean;
+  loadExternalFavorites: () => Promise<void>;
+}
+
+export const useFavorites = create<FavoritesStore>((set, get) => ({
+  favoriteIds: [],
+
+  addExternalFavorite: async (hackathon: ExternalHackathon) => {
+    try {
+      await axios.post("/api/external-favorites", {
+        externalId: hackathon.id,
+        title: hackathon.title,
+        url: hackathon.url,
+        logo: hackathon.logo,
+        platform: hackathon.platform,
+        mode: hackathon.mode,
+        location: hackathon.location,
+        status: hackathon.status,
+      });
+      
+      const favoriteKey = `${hackathon.platform}-${hackathon.id}`;
+      set((state) => ({
+        favoriteIds: [...state.favoriteIds, favoriteKey],
+      }));
+      toast.success("Added to favorites!");
+    } catch (error) {
+      toast.error("Failed to add to favorites");
+      console.error(error);
+    }
+  },
+
+  removeExternalFavorite: async (externalId: string, platform: string) => {
+    try {
+      await axios.post("/api/external-favorites", {
+        externalId,
+        platform,
+      });
+      
+      const favoriteKey = `${platform}-${externalId}`;
+      set((state) => ({
+        favoriteIds: state.favoriteIds.filter((id) => id !== favoriteKey),
+      }));
+      toast.success("Removed from favorites!");
+    } catch (error) {
+      toast.error("Failed to remove from favorites");
+      console.error(error);
+    }
+  },
+
+  toggleExternalFavorite: async (hackathon: ExternalHackathon) => {
+    const isFavorited = get().isExternalFavorited(hackathon.id, hackathon.platform);
+    if (isFavorited) {
+      await get().removeExternalFavorite(hackathon.id, hackathon.platform);
+    } else {
+      await get().addExternalFavorite(hackathon);
+    }
+    // Reload favorites to ensure consistency
+    await get().loadExternalFavorites();
+  },
+
+  isExternalFavorited: (externalId: string, platform: string) => {
+    const favoriteKey = `${platform}-${externalId}`;
+    return get().favoriteIds.includes(favoriteKey);
+  },
+
+  loadExternalFavorites: async () => {
+    try {
+      const response = await axios.get("/api/external-favorites");
+      const favorites = response.data;
+      const favoriteKeys = favorites.map((fav: any) => `${fav.platform}-${fav.externalId}`);
+      set({
+        favoriteIds: favoriteKeys,
+      });
+    } catch (error) {
+      console.error("Failed to load favorites", error);
+      toast.error("Failed to load favorites");
+    }
+  },
+}));

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -2,7 +2,6 @@ import type { NextAuthConfig } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import { GetUserByEmail } from "./data/user";
 import { LoginSchema } from "./validation";
-import bcrypt from "bcryptjs"
 import Github from "next-auth/providers/github"
 import Google from "next-auth/providers/google"
 export default ({
@@ -28,7 +27,7 @@ export default ({
             const user = await GetUserByEmail(email);
        
             if (!user || !user.password) return null;
-       
+            const { default: bcrypt } = await import("bcryptjs");
             const passwordsMatch = await bcrypt.compare(password, user.password);
             if (!passwordsMatch) {
               console.error("Passwords do not match");

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -17,7 +17,6 @@ export default ({
         Credentials({
         async authorize(credentials) {
           const validatedFields = LoginSchema.safeParse(credentials);
-          console.log("credentials",credentials);
           if (!validatedFields.success) {
             return null;
           }
@@ -33,9 +32,14 @@ export default ({
               console.error("Passwords do not match");
               return null;
             }
-  
-            console.log("User authenticated successfully:", user);
-            return user;
+            // Intentionally not logging user details to avoid PII in logs
+            const safeUser = {
+              id: user.id,
+              name: user.name ?? null,
+              email: user.email ?? null,
+              image: (user as any).image ?? null,
+            };
+            return safeUser;
           }
        
           return null;

--- a/components/heading.tsx
+++ b/components/heading.tsx
@@ -1,0 +1,31 @@
+import { IconType } from "react-icons";
+
+interface HeadingProps {
+  title: string;
+  description: string;
+  icon: IconType;
+  iconColor?: string;
+  bgColor?: string;
+}
+
+export const Heading = ({
+  title,
+  description,
+  icon: Icon,
+  iconColor,
+  bgColor,
+}: HeadingProps) => {
+  return (
+    <div className="px-4 lg:px-8 flex items-center gap-x-3 mb-8">
+      <div className={`p-2 w-fit rounded-md ${bgColor}`}>
+        <Icon className={`w-10 h-10 ${iconColor}`} />
+      </div>
+      <div>
+        <h2 className="text-3xl font-bold">{title}</h2>
+        <p className="text-sm text-muted-foreground">
+          {description}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/lib/store/features/favoritesSlice/favoritesSlice.ts
+++ b/lib/store/features/favoritesSlice/favoritesSlice.ts
@@ -30,7 +30,14 @@ const initialState: FavoritesState = {
 // Async thunks
 export const loadExternalFavorites = createAsyncThunk(
   'favorites/loadExternalFavorites',
-  async (_, { rejectWithValue }) => {
+  async (_, { rejectWithValue, getState }) => {
+    const state = getState() as RootState;
+    
+    // Skip if already loading to prevent duplicate requests
+    if (state.favorites.loading) {
+      return rejectWithValue("Already loading favorites");
+    }
+    
     try {
       const response = await axios.get("/api/external-favorites");
       const favorites = response.data;
@@ -97,8 +104,7 @@ export const toggleExternalFavorite = createAsyncThunk(
       await dispatch(addExternalFavorite(hackathon));
     }
     
-    // Reload favorites to ensure consistency
-    await dispatch(loadExternalFavorites());
+    // Remove redundant loadExternalFavorites call - optimistic updates handle state
   }
 );
 

--- a/lib/store/features/favoritesSlice/favoritesSlice.ts
+++ b/lib/store/features/favoritesSlice/favoritesSlice.ts
@@ -1,0 +1,166 @@
+import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
+import axios from "axios";
+import { RootState } from "../../store";
+
+interface ExternalHackathon {
+  id: string;
+  title: string;
+  url: string;
+  logo?: string;
+  platform: string;
+  mode?: string;
+  location?: string;
+  status?: string;
+}
+
+interface FavoritesState {
+  favoriteIds: string[];
+  favorites: ExternalHackathon[];
+  loading: boolean;
+  error: string | null;
+}
+
+const initialState: FavoritesState = {
+  favoriteIds: [],
+  favorites: [],
+  loading: false,
+  error: null,
+};
+
+// Async thunks
+export const loadExternalFavorites = createAsyncThunk(
+  'favorites/loadExternalFavorites',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await axios.get("/api/external-favorites");
+      const favorites = response.data;
+      const favoriteKeys = favorites.map((fav: any) => `${fav.platform}-${fav.externalId}`);
+      return { favorites, favoriteKeys };
+    } catch (error) {
+      console.error("Failed to load favorites", error);
+      return rejectWithValue("Failed to load favorites");
+    }
+  }
+);
+
+export const addExternalFavorite = createAsyncThunk(
+  'favorites/addExternalFavorite',
+  async (hackathon: ExternalHackathon, { rejectWithValue, dispatch }) => {
+    try {
+      await axios.post("/api/external-favorites", {
+        externalId: hackathon.id,
+        title: hackathon.title,
+        url: hackathon.url,
+        logo: hackathon.logo,
+        platform: hackathon.platform,
+        mode: hackathon.mode,
+        location: hackathon.location,
+        status: hackathon.status,
+      });
+      
+      const favoriteKey = `${hackathon.platform}-${hackathon.id}`;
+      return favoriteKey;
+    } catch (error) {
+      console.error("Failed to add to favorites", error);
+      return rejectWithValue("Failed to add to favorites");
+    }
+  }
+);
+
+export const removeExternalFavorite = createAsyncThunk(
+  'favorites/removeExternalFavorite',
+  async ({ externalId, platform }: { externalId: string; platform: string }, { rejectWithValue }) => {
+    try {
+      await axios.post("/api/external-favorites", {
+        externalId,
+        platform,
+      });
+      
+      const favoriteKey = `${platform}-${externalId}`;
+      return favoriteKey;
+    } catch (error) {
+      console.error("Failed to remove from favorites", error);
+      return rejectWithValue("Failed to remove from favorites");
+    }
+  }
+);
+
+export const toggleExternalFavorite = createAsyncThunk(
+  'favorites/toggleExternalFavorite',
+  async (hackathon: ExternalHackathon, { getState, dispatch }) => {
+    const state = getState() as RootState;
+    const isFavorited = state.favorites.favoriteIds.includes(`${hackathon.platform}-${hackathon.id}`);
+    
+    if (isFavorited) {
+      await dispatch(removeExternalFavorite({ externalId: hackathon.id, platform: hackathon.platform }));
+    } else {
+      await dispatch(addExternalFavorite(hackathon));
+    }
+    
+    // Reload favorites to ensure consistency
+    await dispatch(loadExternalFavorites());
+  }
+);
+
+const favoritesSlice = createSlice({
+  name: 'favorites',
+  initialState,
+  reducers: {
+    clearFavorites: (state) => {
+      state.favoriteIds = [];
+      state.favorites = [];
+      state.error = null;
+    },
+    setError: (state, action: PayloadAction<string | null>) => {
+      state.error = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // Load favorites
+      .addCase(loadExternalFavorites.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(loadExternalFavorites.fulfilled, (state, action) => {
+        state.loading = false;
+        state.favoriteIds = action.payload.favoriteKeys;
+        state.favorites = action.payload.favorites;
+        state.error = null;
+      })
+      .addCase(loadExternalFavorites.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload as string;
+      })
+      // Add favorite
+      .addCase(addExternalFavorite.fulfilled, (state, action) => {
+        if (!state.favoriteIds.includes(action.payload)) {
+          state.favoriteIds.push(action.payload);
+        }
+        state.error = null;
+      })
+      .addCase(addExternalFavorite.rejected, (state, action) => {
+        state.error = action.payload as string;
+      })
+      // Remove favorite
+      .addCase(removeExternalFavorite.fulfilled, (state, action) => {
+        state.favoriteIds = state.favoriteIds.filter(id => id !== action.payload);
+        state.error = null;
+      })
+      .addCase(removeExternalFavorite.rejected, (state, action) => {
+        state.error = action.payload as string;
+      });
+  },
+});
+
+export const { clearFavorites, setError } = favoritesSlice.actions;
+
+// Selectors
+export const selectFavorites = (state: RootState) => state.favorites;
+export const selectFavoriteIds = (state: RootState) => state.favorites.favoriteIds;
+export const selectIsExternalFavorited = (externalId: string, platform: string) => (state: RootState) => {
+  const favoriteKey = `${platform}-${externalId}`;
+  return state.favorites.favoriteIds.includes(favoriteKey);
+};
+
+export default favoritesSlice.reducer;

--- a/lib/store/store.ts
+++ b/lib/store/store.ts
@@ -3,6 +3,7 @@ import authReducer from './features/authSlice/authSlice'
 import filterReducer from './features/filterSlice/filterSlice'
 import postReducer from './features/postSlice/postSlice'
 import userReducer from './features/userSlice/userSlice'
+import favoritesReducer from './features/favoritesSlice/favoritesSlice'
 
 export const makeStore = () => {
   return configureStore({
@@ -11,6 +12,7 @@ export const makeStore = () => {
         filter: filterReducer,
         post: postReducer,
         user: userReducer,
+        favorites: favoritesReducer,
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.52.0",
-    "react-hot-toast": "^2.5.2",
     "react-icons": "^5.2.1",
     "react-otp-input": "^3.1.1",
     "react-redux": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.52.0",
+    "react-hot-toast": "^2.5.2",
     "react-icons": "^5.2.1",
     "react-otp-input": "^3.1.1",
     "react-redux": "^9.1.2",
@@ -66,7 +67,8 @@
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^10.0.0",
     "vaul": "^0.9.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zustand": "^5.0.7"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^10.0.0",
     "vaul": "^0.9.1",
-    "zod": "^3.23.8",
-    "zustand": "^5.0.7"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,7 +31,7 @@ model User {
   linkedinUrl  String?  
   githubUrl    String? 
   skills       String[]
-  favoriteHackathons UserFavoriteHackathon[]
+
   externalFavorites ExternalHackathonFavorite[]
 }
 
@@ -72,19 +72,10 @@ model Hackathon {
   updatedAt      DateTime     @updatedAt
   applications   Application[]
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
-  favoritedBy    UserFavoriteHackathon[]
+
 }
 
-model UserFavoriteHackathon {
-  id          String    @id @default(cuid())
-  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId      String
-  hackathon   Hackathon @relation(fields: [hackathonId], references: [id], onDelete: Cascade)
-  hackathonId String
-  createdAt   DateTime  @default(now())
 
-  @@unique([userId, hackathonId])
-}
 
 model ExternalHackathonFavorite {
   id              String   @id @default(cuid())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,8 @@ model User {
   linkedinUrl  String?  
   githubUrl    String? 
   skills       String[]
+  favoriteHackathons UserFavoriteHackathon[]
+  externalFavorites ExternalHackathonFavorite[]
 }
 
 model Account {
@@ -70,6 +72,35 @@ model Hackathon {
   updatedAt      DateTime     @updatedAt
   applications   Application[]
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  favoritedBy    UserFavoriteHackathon[]
+}
+
+model UserFavoriteHackathon {
+  id          String    @id @default(cuid())
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId      String
+  hackathon   Hackathon @relation(fields: [hackathonId], references: [id], onDelete: Cascade)
+  hackathonId String
+  createdAt   DateTime  @default(now())
+
+  @@unique([userId, hackathonId])
+}
+
+model ExternalHackathonFavorite {
+  id              String   @id @default(cuid())
+  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId          String
+  externalId      String   // ID from external API
+  title           String
+  url             String
+  logo            String?
+  platform        String   // 'unstop', 'devpost', 'devfolio'
+  mode            String?
+  location        String?
+  status          String?
+  createdAt       DateTime @default(now())
+
+  @@unique([userId, externalId, platform])
 }
 
 model Application {

--- a/public/star.svg
+++ b/public/star.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
Fixes #160  .looks like this now:

https://github.com/user-attachments/assets/e5374a08-347f-4e0e-a603-548e1ae37441

1) starring and unstarring a hackathon card will add and remove from favorites tab
2) if not logged in, hovering on star will subtly ask to login first
3) if not logged in, clicking on favorites tab will redirect to login 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a "Favorites" section accessible from the main and mobile navigation, allowing users to view and manage their favorite hackathons.
  * Added the ability to favorite or unfavorite hackathons directly from hackathon and team listings using a star icon.
  * Implemented a dedicated favorites list page with asynchronous loading and clear messaging for empty states.
  * Favorites are synced across sessions and devices for authenticated users.
  * Added an API to manage external hackathon favorites.
  * Introduced a new "Favorites" tab and floating button on the hackathons page for quick access.
  * Added a reusable heading component with icon support for consistent section titles.

* **Bug Fixes**
  * Ensured only authenticated users can access and manage favorites, with redirection to login when necessary.

* **User Interface**
  * Enhanced hackathon cards and team posts with interactive favorite buttons and visual indicators.

* **Performance**
  * Incorporated asynchronous loading and state management for a responsive favorites experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->