### PR TITLE
Fixed the overlapping card issue in post tab

### DIFF
--- a/app/(dashboard)/(routes)/teams/components/PostsTab.tsx
+++ b/app/(dashboard)/(routes)/teams/components/PostsTab.tsx
@@ -66,7 +66,7 @@ useEffect(() => {
   });
 
   return (
-    <div className='w-full min-h-[50vh] grid sm:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-4 flex-wrap '>
+    <div className='w-full min-h-[50vh]'>
 
       {loading ? (
         <Loading />


### PR DESCRIPTION
fixes : #167 

<img width="1824" height="508" alt="Screenshot from 2025-09-05 00-31-15" src="https://github.com/user-attachments/assets/e8aa1908-e41e-4b03-9c58-96843adccecf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout of the Teams > Posts tab by removing an outer grid wrapper. The loading state now spans the full width for clearer visibility, while the posts continue to display within the existing responsive grid. This results in a cleaner, more consistent appearance during loading without affecting how posts are presented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->